### PR TITLE
Skip the "Website URL" message at the end of deploy on failing getPullZone

### DIFF
--- a/app/Bunny/Filesystem/FileCompare.php
+++ b/app/Bunny/Filesystem/FileCompare.php
@@ -138,9 +138,11 @@ class FileCompare
         $this->command->info(sprintf($message, number_format($timeElapsedSecs, 2)));
         $this->command->newLine();
 
-        foreach ($result->getData()->Hostnames as $hostname) {
-            $schema = ($hostname->ForceSSL || $hostname->HasCertificate) ? 'https' : 'http';
-            $this->command->info(sprintf('Website URL: %s://%s', $schema, $hostname->Value));
+        if ($result->success()) {
+            foreach ($result->getData()->Hostnames as $hostname) {
+                $schema = ($hostname->ForceSSL || $hostname->HasCertificate) ? 'https' : 'http';
+                $this->command->info(sprintf('Website URL: %s://%s', $schema, $hostname->Value));
+            }
         }
     }
 


### PR DESCRIPTION
When I run `bunny deploy` locally, everything works as intended. But when I use the action in GitHub, `getPullZone` causes a 401 (Unauthorized) response. I don't know why this happens at this point.

The 401 response has no body. Consequently, `json_decode` returns `NULL`, and `$result->getData()->Hostnames` causes:
```
Attempt to read property "Hostnames" on null
```

This issue [may have been reported earlier](https://github.com/own3d/bunny-action/issues/2), although that might be something else.

I added an if-block prevent the failure, at the expense of the "Website URL" message. This may not be the ideal solution. If you have any suggestions, please let me know.